### PR TITLE
Repo code not working, i've fixed it.

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,11 +18,11 @@ config = configparser.RawConfigParser()
 config.read('secrets.ini')
 
 tokens = {
-    'b': config.get('Tokens', 'b'),
-    'lat': config.get('Tokens', 'lat')
+    'p-b': config.get('Tokens', 'b'),
+    'p-lat': config.get('Tokens', 'lat')
 }
 
-client = PoeApi(cookie=tokens)
+client = PoeApi(tokens=tokens)
 
 bot = config.get('Bot', 'bot_name')
 


### PR DESCRIPTION
I've changed two things that needed to be changed with the latest poe-api-wrapper version:

cookie has to be renamed tokens
and
the cookies must been renamed p-b and p-lat 

for the code to return working.

I suggest changing documentation for reflecting the new changes in Poe.com Cookies.

Thanks for this great piece of code, from Taranto, Italy.